### PR TITLE
Simplify code by excluding unnecessary json parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,3 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.11.2

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def obj_as_js_var(var_name, obj, content_for_name = nil)
-    str = "var #{var_name} = JSON.parse(\"#{obj.to_json.gsub('"', '\"')}\")"
+    str = "var #{var_name} = #{obj.to_json}"
     output = javascript_tag(str, type: 'text/javascript')
     if content_for_name
       content_for content_for_name, output


### PR DESCRIPTION
This produces exactly the same output on the page. As to why it happens, I suggest you inspect the resulting page source in both cases.